### PR TITLE
Update jiant.info pre-ACL

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 						<div class="col-md-10 text-right menu-1">
 							<ul>
 								<li class="active"><a href="index.html">Home</a></li>
-								<li><a href="https://github.com/nyu-mll/jiant/">GitHub</a></li>
+								<!-- <li><a href="https://github.com/nyu-mll/jiant/">GitHub</a></li> -->
 								<li><a href="https://arxiv.org/abs/2003.02249">Paper</a></li>
 								<li><a href="documentation/#">Documentation</a></li>
 							</ul>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
 								<li class="active"><a href="index.html">Home</a></li>
 								<!-- <li><a href="https://github.com/nyu-mll/jiant/">GitHub</a></li> -->
 								<li><a href="https://arxiv.org/abs/2003.02249">Paper</a></li>
-								<li><a href="documentation/#">Documentation</a></li>
+								<!-- <li><a href="documentation/#">Documentation</a></li> -->
 							</ul>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -81,9 +81,9 @@
 					<div class="container">
 						<div class="col-md-12 col-md-offset-0">
 							<div class="animate-box">
-								<h2><code>jiant</code></h2>
-								<p>A software toolkit for research on general-purpose text understanding models.</p>
-								<p><a href="https://github.com/nyu-mll/jiant/blob/master/tutorials/setup_tutorial.md" class="btn btn-primary btn-lg btn-custom">Get Started</a> <a href="https://github.com/nyu-mll/jiant/" class="btn btn-primary btn-lg btn-custom">View on GitHub</a></p>
+								<h2 style="font-family: Menlo, Monaco, Consolas, Courier New, monospace;">jiant</h2></span>
+								<p>A software toolkit for research <br> on general-purpose text understanding models.</p>
+								<p><a href="https://github.com/nyu-mll/jiant" class="btn btn-primary btn-lg btn-custom">jiant v1.3 (Legacy)</a> <a href="https://github.com/jiant-dev/jiant" class="btn btn-primary btn-lg btn-custom">jiant v2 (Pre-Alpha)</a></p>
 							</div>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -104,8 +104,7 @@ A few things you might want to know about <code>jiant</code>:
 <li><code>jiant</code> contains implementations of strong baselines for the <a href="https://gluebenchmark.com">GLUE</a> and <a href="https://gluebenchmark.com/super">SuperGLUE</a> benchmarks, and it's the recommended starting point for work on these benchmarks.</li>
 <li><code>jiant</code> was developed at <a href="https://www.clsp.jhu.edu/workshops/18-workshop/">the 2018 JSALT Workshop</a> by <a href="https://jsalt18-sentence-repl.github.io/">the General-Purpose Sentence Representation Learning team</a> and is maintained by <a href="https://wp.nyu.edu/ml2/">the NYU Machine Learning for Language Lab</a>, with help from many outside collaborators (especially Google AI Language's <a href="https://ai.google/research/people/IanTenney">Ian Tenney</a>).</li>
 <li><code>jiant</code> is built on <a href="https://pytorch.org">PyTorch</a>. It also uses many components from <a href="https://github.com/allenai/allennlp">AllenNLP</a> and the HuggingFace <a href="https://github.com/huggingface/pytorch-pretrained-BERT">PyTorch Transformers</a> package.</li>
-</ul>
-For more information on <code>jiant</code> or to install a copy yourself, have a look at our <a href="https://github.com/nyu-mll/jiant">GitHub repository</a>.
+  </ul>
 
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 							<div class="animate-box">
 								<h2 style="font-family: Menlo, Monaco, Consolas, Courier New, monospace;">jiant</h2></span>
 								<p>A software toolkit for research <br> on general-purpose text understanding models.</p>
-								<p><a href="https://github.com/nyu-mll/jiant" class="btn btn-primary btn-lg btn-custom">jiant v1.3 (Legacy)</a> <a href="https://github.com/jiant-dev/jiant" class="btn btn-primary btn-lg btn-custom">jiant v2 (Pre-Alpha)</a></p>
+								<p><a href="https://github.com/nyu-mll/jiant" class="btn btn-primary btn-lg btn-custom">jiant v1.3</a> <a href="https://github.com/jiant-dev/jiant" class="btn btn-primary btn-lg btn-custom">jiant v2 (Alpha)</a></p>
 							</div>
 						</div>
 					</div>
@@ -104,7 +104,7 @@ A few things you might want to know about <code>jiant</code>:
 <li><code>jiant</code> contains implementations of strong baselines for the <a href="https://gluebenchmark.com">GLUE</a> and <a href="https://gluebenchmark.com/super">SuperGLUE</a> benchmarks, and it's the recommended starting point for work on these benchmarks.</li>
 <li><code>jiant</code> was developed at <a href="https://www.clsp.jhu.edu/workshops/18-workshop/">the 2018 JSALT Workshop</a> by <a href="https://jsalt18-sentence-repl.github.io/">the General-Purpose Sentence Representation Learning team</a> and is maintained by <a href="https://wp.nyu.edu/ml2/">the NYU Machine Learning for Language Lab</a>, with help from many outside collaborators (especially Google AI Language's <a href="https://ai.google/research/people/IanTenney">Ian Tenney</a>).</li>
 <li><code>jiant</code> is built on <a href="https://pytorch.org">PyTorch</a>. It also uses many components from <a href="https://github.com/allenai/allennlp">AllenNLP</a> and the HuggingFace <a href="https://github.com/huggingface/pytorch-pretrained-BERT">PyTorch Transformers</a> package.</li>
-  </ul>
+</ul>
 
 				</div>
 			</div>


### PR DESCRIPTION
This PR...
1. Removes the page header link to Github (v1.3.X)
2. Update the main button-links to point to 1.3 and 2 (Alpha) repos
3. Makes some minor style adjustments to the title text
4. Removes the link to the jiant-site documentation resources
5. Removes outdated explanation of acronym and redundant link

After:
![Screen Shot 2020-07-06 at 8 06 57 AM](https://user-images.githubusercontent.com/6176602/86591514-be13fa00-bf5f-11ea-8f21-2f8262368ae2.png)
